### PR TITLE
deduplicate MRO slots list

### DIFF
--- a/parsely_raw_data/event.py
+++ b/parsely_raw_data/event.py
@@ -30,9 +30,14 @@ class SlotsMixin(object):
         mro_slots = [item for slots in
                      [a.__slots__ for a in type(self).mro() if hasattr(a, "__slots__")]
                      for item in slots]
-        # deduplicate mro slots list
-        mro_slots = list(set(mro_slots))
-        return (p for p in mro_slots if not p.startswith('_'))
+        seen = set()
+        deduplicated_slots = []
+        for item in mro_slots:
+            if item in seen:
+                continue
+            seen.add(item)
+            deduplicated_slots.append(item)
+        return (p for p in deduplicated_slots if not p.startswith('_'))
 
     def __eq__(self, other):
         """Compare and return True if all public attributes are equal."""

--- a/parsely_raw_data/event.py
+++ b/parsely_raw_data/event.py
@@ -45,6 +45,8 @@ class SlotsMixin(object):
         mro_slots = [item for slots in
                      [a.__slots__ for a in type(self).mro() if hasattr(a, "__slots__")]
                      for item in slots]
+        # deduplicate mro slots list
+        mro_slots = list(set(mro_slots))
         vals = ', '.join('{}={!r}'.format(s, getattr(self, s, None))
                          for s in mro_slots
                          if not s.startswith('_'))

--- a/parsely_raw_data/event.py
+++ b/parsely_raw_data/event.py
@@ -32,6 +32,8 @@ class SlotsMixin(object):
         mro_slots = [item for slots in
                      [a.__slots__ for a in type(self).mro() if hasattr(a, "__slots__")]
                      for item in slots]
+        # deduplicate mro slots list
+        mro_slots = list(set(mro_slots))
         return all(getattr(self, p) == getattr(other, p)
                    for p in mro_slots
                    if not p.startswith('_'))


### PR DESCRIPTION
Fixes https://github.com/Parsely/casterisk/issues/402 by deduplicating the list of properties from the `__slots__` list of all classes in the `mro()` of the class having `__repr__` called on it.