### PR TITLE
[WIP] Add a unified schema definition in JSON, output for Markdown tables, BigQuery, Redshift, etc.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,28 +4,48 @@
 Parse.ly Raw Data
 =================
 
-This repository contains Python example code for working with Parse.ly's
-"raw data API". This "API" comprises a collection of AWS tools that Parse.ly
-customers can use to gain batch and streaming access to the raw data that Parse.ly
-collects from their sites. Streaming access is provided via Amazon Kinesis Streams,
-and batch access via Amazon S3.
+This repository contains Python example code for working with raw data delivered
+by Parse.ly's fully-managed Data Pipeline product, at http://parse.ly/data-pipeline.
 
-To set up Raw Data API access for your Parse.ly account, please contact
-Parse.ly support.
+This Python repository is a suite of tools, mostly usable from the command-line,
+which make it easy to evaluate and integrate the Parse.ly raw data.
 
-You can download this repository with
+Customers can use this repository to:
+
+* gain batch and streaming access to the raw data that Parse.ly
+  collects from their sites; streaming access is provided via Amazon Kinesis Streams,
+  and batch access via Amazon S3
+
+* generate schemas and DDL for common data warehousing tools, such as Redshift,
+  BigQuery, and Apache Spark
+
+* create data samples that can be evaluated using in-memory analyst tools such
+  as Excel or R Studio (xlsx/csv samples)
+
+To make use of Parse.ly raw data, you must be a customer of Parse.ly's Data Pipeline
+product. To gain access for your Parse.ly account, please contact Parse.ly directly
+at http://help.parsely.com.
+
+You can download this repository by cloning it from Github, e.g.
 
 ::
+    $ git clone https://github.com/Parsely/parsely_raw_data.git
 
+Or, you can install it into an environment with `pip`, e.g.
+
+::
     $ pip install parsely_raw_data
 
-The files in this module are named for the services they interface with:
+The files in this module are named for the services they interface with. You can simply
+run modules to use command-line tools provided, or import the modules to script
+them yourselves using your own Python scripts.
 
-* `s3.py`: Fetch event data from a Parse.ly-managed S3 bucket
-* `stream.py`: Consume a Kinesis Stream of realtime Parse.ly event data
-* `redshift.py`: Copy data from S3 to an Amazon Redshift instance
-* `bigquery.py`: Write event data to a Google BigQuery table
+Module and CLI Guide
+~~~~~~~~~~~~~~~~~~~~
 
-This repository also contains a Thrift-based abstraction over a Parse.ly event
-called `Event`. This class is used to standardize the format of events
-passed around between various services.
+* `python -m parsely_raw_data.samples`: Generate data samples in CSV and XLSX format
+* `python -m parsely_raw_data.s3`: Fetch event data from a Parse.ly-managed S3 bucket
+* `python -m parsely_raw_data.kinesis`: Consume a Kinesis Stream of realtime Parse.ly event data
+* `python -m parsely_raw_data.schema`: Generates schemas for Redshift, BigQuery, and Spark
+* `python -m parsely_raw_data.redshift`: Copy JSON data from S3 to an Amazon Redshift instance
+* `python -m parsely_raw_data.bigquery`: Copy JSON event data to a Google BigQuery table

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,13 @@ at http://help.parsely.com.
 You can download this repository by cloning it from Github, e.g.
 
 ::
+
     $ git clone https://github.com/Parsely/parsely_raw_data.git
 
 Or, you can install it into an environment with `pip`, e.g.
 
 ::
+
     $ pip install parsely_raw_data
 
 The files in this module are named for the services they interface with. You can simply
@@ -44,8 +46,8 @@ Module and CLI Guide
 ~~~~~~~~~~~~~~~~~~~~
 
 * `python -m parsely_raw_data.samples`: Generate data samples in CSV and XLSX format
-* `python -m parsely_raw_data.s3`: Fetch event data from a Parse.ly-managed S3 bucket
-* `python -m parsely_raw_data.kinesis`: Consume a Kinesis Stream of realtime Parse.ly event data
-* `python -m parsely_raw_data.schema`: Generates schemas for Redshift, BigQuery, and Spark
-* `python -m parsely_raw_data.redshift`: Copy JSON data from S3 to an Amazon Redshift instance
-* `python -m parsely_raw_data.bigquery`: Copy JSON event data to a Google BigQuery table
+* `python -m parsely_raw_data.s3`: Fetch archived event data from Parse.ly S3 Bucket
+* `python -m parsely_raw_data.kinesis`: Consume a Parse.ly Kinesis Stream of real-time event data
+* `python -m parsely_raw_data.schema`: Inspect schemas for Redshift, BigQuery, and Spark
+* `python -m parsely_raw_data.redshift`: Create an Amazon Redshift table for events and load data
+* `python -m parsely_raw_data.bigquery`: Create a Google BigQuery table for events and load data

--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,9 @@ them yourselves using your own Python scripts.
 Module and CLI Guide
 ~~~~~~~~~~~~~~~~~~~~
 
-* `python -m parsely_raw_data.samples`: Generate data samples in CSV and XLSX format
-* `python -m parsely_raw_data.s3`: Fetch archived event data from Parse.ly S3 Bucket
-* `python -m parsely_raw_data.kinesis`: Consume a Parse.ly Kinesis Stream of real-time event data
-* `python -m parsely_raw_data.schema`: Inspect schemas for Redshift, BigQuery, and Spark
-* `python -m parsely_raw_data.redshift`: Create an Amazon Redshift table for events and load data
-* `python -m parsely_raw_data.bigquery`: Create a Google BigQuery table for events and load data
+* ``python -m parsely_raw_data.samples``: Generate data samples in CSV and XLSX format
+* ``python -m parsely_raw_data.s3``: Fetch archived event data from Parse.ly S3 Bucket
+* ``python -m parsely_raw_data.kinesis``: Consume a Parse.ly Kinesis Stream of real-time event data
+* ``python -m parsely_raw_data.schema``: Inspect schemas for Redshift, BigQuery, and Spark
+* ``python -m parsely_raw_data.redshift``: Create an Amazon Redshift table for events and load data
+* ``python -m parsely_raw_data.bigquery``: Create a Google BigQuery table for events and load data

--- a/parsely_raw_data/bigquery.py
+++ b/parsely_raw_data/bigquery.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 import pprint
+import json
 
 from googleapiclient.discovery import build as google_build
 from oauth2client.client import GoogleCredentials
@@ -179,9 +180,10 @@ def main():
         )
     elif args.command == "create_table":
         create_table(
-            project_id=args.project_id,
-            dataset_id=args.dataset_id,
-            table_id=args.table_id
+            project_id=args.bigquery_project_id,
+            dataset_id=args.bigquery_dataset_id,
+            table_id=args.bigquery_table_id,
+            debug=args.debug
         )
 
 if __name__ == "__main__":

--- a/parsely_raw_data/bigquery.py
+++ b/parsely_raw_data/bigquery.py
@@ -9,7 +9,7 @@ from six import iteritems
 
 from . import utils
 from .s3 import events_s3
-from .schema import mk_bigquery_table
+from .schema import mk_bigquery_schema
 
 
 __license__ = """
@@ -129,7 +129,7 @@ def create_table(project_id, table_id, dataset_id, debug=False):
     :param dataset_id: The BigQuery dataset ID to write to
     :type dataset_id: str
     """
-    fields = mk_bigquery_table()
+    fields = mk_bigquery_schema()
     schema = {
         "description": "Parse.ly Data Pipeline",
         "schema": {"fields": fields},

--- a/parsely_raw_data/bigquery.py
+++ b/parsely_raw_data/bigquery.py
@@ -116,7 +116,7 @@ def copy_from_s3(network,
                 yield chunk
                 chunk = []
     for events in chunked(s3_stream, 500):
-        write_events_bigquery(events, bq_conn=bq_conn, project_id=project_id,
+        streaming_insert_bigquery(events, bq_conn=bq_conn, project_id=project_id,
                               dataset_id=dataset_id, table_id=table_id)
 
 

--- a/parsely_raw_data/bigquery.py
+++ b/parsely_raw_data/bigquery.py
@@ -9,6 +9,7 @@ from six import iteritems
 
 from . import utils
 from .s3 import events_s3
+from .schema import mk_bigquery_table
 
 
 __license__ = """
@@ -27,30 +28,11 @@ limitations under the License.
 log = logging.getLogger(__name__)
 
 
-def event_to_bigquery(event):
-    """Convert a Event instance to a BigQuery-formatted dict
-
-    Compatible with the schema implemented by `create_bigquery_table`
-
-    :param event: The Event instance to convert
-    :type event: pixel_logs.Event
-    """
-    ret = event.to_dict()
-    timestamp_fields = ["session.last_session_timestamp", "session.timestamp",
-                        "timestamp_info.nginx_ms", "timestamp_info.override_ms",
-                        "timestamp_info.pixel_ms"]
-    for k, v in iteritems(ret):
-        # convert timestamps to seconds
-        if v and k in timestamp_fields:
-            ret[k] = v / 1000
-    return {"json": ret}
-
-
-def write_events_bigquery(events,
-                          bq_conn=None,
-                          project_id=None,
-                          dataset_id=None,
-                          table_id=None):
+def streaming_insert_bigquery(jsonlines,
+                              bq_conn=None,
+                              project_id=None,
+                              dataset_id=None,
+                              table_id=None):
     """Write a stream of events to BigQuery
 
     :param bq_conn: The BigQuery connection to write to
@@ -66,7 +48,7 @@ def write_events_bigquery(events,
         "kind": "bigquery#tableDataInsertAllRequest",
         "skipInvalidRows": False,
         "ignoreUnknownValues": False,
-        "rows": [event_to_bigquery(event) for event in events]
+        "rows": [jsonline for jsonline in jsonlines]
     }
     if bq_conn is None:
         pprint.PrettyPrinter(indent=0).pprint(insert_body)
@@ -84,16 +66,16 @@ def write_events_bigquery(events,
     return True
 
 
-def load_batch_bigquery(network,
-                        s3_prefix="",
-                        access_key_id="",
-                        secret_access_key="",
-                        region_name="us-east-1",
-                        project_id=None,
-                        dataset_id=None,
-                        table_id=None,
-                        dry_run=False):
-    """Load a batch of events from S3 to BigQuery
+def copy_from_s3(network,
+                 s3_prefix="",
+                 access_key_id="",
+                 secret_access_key="",
+                 region_name="us-east-1",
+                 project_id=None,
+                 dataset_id=None,
+                 table_id=None,
+                 dry_run=False):
+    """Load events from S3 to BigQuery using the BQ streaming insert API.
 
     :param network: The Parse.ly network for which to perform writes (eg
         "parsely-blog")
@@ -137,7 +119,7 @@ def load_batch_bigquery(network,
                               dataset_id=dataset_id, table_id=table_id)
 
 
-def create_bigquery_table(project_id, table_id, dataset_id):
+def create_table(project_id, table_id, dataset_id, debug=False):
     """Create a BigQuery table using a schema compatible with Parse.ly events
 
     :param project_id: The BigQuery project ID to write to
@@ -147,41 +129,19 @@ def create_bigquery_table(project_id, table_id, dataset_id):
     :param dataset_id: The BigQuery dataset ID to write to
     :type dataset_id: str
     """
+    fields = mk_bigquery_table()
     schema = {
-        "description": "Parse.ly event data",
-        "schema": {"fields": [
-            {"name": "url", "mode": "REQUIRED", "type": "STRING"},
-            {"name": "apikey", "mode": "REQUIRED", "type": "STRING"},
-            {"name": "action", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "display_avail_height", "mode": "NULLABLE", "type": "INTEGER"},
-            {"name": "display_avail_width", "mode": "NULLABLE", "type": "INTEGER"},
-            {"name": "display_pixel_depth", "mode": "NULLABLE", "type": "INTEGER"},
-            {"name": "display_total_height", "mode": "NULLABLE", "type": "INTEGER"},
-            {"name": "display_total_width", "mode": "NULLABLE", "type": "INTEGER"},
-            {"name": "engaged_time_inc", "mode": "NULLABLE", "type": "INTEGER"},
-            {"name": "extra_data", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "referrer", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "session_id", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "session_initial_referrer", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "session_initial_url", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "session_last_session_timestamp", "mode": "NULLABLE",
-                "type": "TIMESTAMP"},
-            {"name": "session_timestamp", "mode": "NULLABLE", "type": "TIMESTAMP"},
-            {"name": "timestamp_info_nginx_ms", "mode": "NULLABLE", "type": "TIMESTAMP"},
-            {"name": "timestamp_info_override_ms", "mode": "NULLABLE",
-                "type": "TIMESTAMP"},
-            {"name": "timestamp_info_pixel_ms", "mode": "NULLABLE", "type": "TIMESTAMP"},
-            {"name": "user_agent", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "visitor_ip", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "visitor_network_id", "mode": "NULLABLE", "type": "STRING"},
-            {"name": "visitor_site_id", "mode": "NULLABLE", "type": "STRING"}
-        ]},
+        "description": "Parse.ly Data Pipeline",
+        "schema": {"fields": fields},
         "tableReference": {
             "projectId": project_id,
             "tableId": table_id,
             "datasetId": dataset_id
         }
     }
+    if debug:
+        print("Running the following BigQuery JSON table insert:")
+        print(json.dumps(schema, indent=4, sort_keys=True))
     credentials = GoogleCredentials.get_application_default()
     bigquery = google_build('bigquery', 'v2', credentials=credentials)
     bigquery.tables().insert(projectId=project_id,
@@ -191,22 +151,22 @@ def create_bigquery_table(project_id, table_id, dataset_id):
 
 
 def main():
-    commands = ["load_batch_bigquery", "create_bigquery_table"]
+    commands = ["copy_from_s3", "create_table"]
     parser = utils.get_default_parser("Google BigQuery utilities for Parse.ly",
                                       commands=commands)
     parser.add_argument('--dry_run', action="store_true",
                         help="If true, don't perform writes to Bigquery"
                              'connect, ending in "redshift.amazonaws.com"')
-    parser.add_argument('bigquery_project_id', type=str,
+    parser.add_argument('--bigquery_project_id', type=str,
                         help='The ID of the BigQuery project to which to connect')
-    parser.add_argument('bigquery_dataset_id', type=str,
+    parser.add_argument('--bigquery_dataset_id', type=str,
                         help='The ID of the BigQuery dataset to which to connect')
-    parser.add_argument('bigquery_table_id', type=str,
+    parser.add_argument('--bigquery_table_id', type=str,
                         help='The ID of the BigQuery table to which to connect')
     args = parser.parse_args()
 
-    if args.command == "load_batch_bigquery":
-        load_batch_bigquery(
+    if args.command == "copy_from_s3":
+        copy_from_s3(
             args.network,
             s3_prefix=args.s3_prefix,
             access_key_id=args.aws_access_key_id,
@@ -217,8 +177,8 @@ def main():
             table_id=args.bigquery_table_id,
             dry_run=args.dry_run
         )
-    elif args.command == "create_bigquery_table":
-        create_bigquery_table(
+    elif args.command == "create_table":
+        create_table(
             project_id=args.project_id,
             dataset_id=args.dataset_id,
             table_id=args.table_id

--- a/parsely_raw_data/bigquery.py
+++ b/parsely_raw_data/bigquery.py
@@ -147,7 +147,6 @@ def create_table(project_id, table_id, dataset_id, debug=False):
     bigquery = google_build('bigquery', 'v2', credentials=credentials)
     bigquery.tables().insert(projectId=project_id,
                              datasetId=dataset_id,
-                             tableId=table_id,
                              body=schema).execute()
 
 

--- a/parsely_raw_data/docgen.py
+++ b/parsely_raw_data/docgen.py
@@ -1,0 +1,63 @@
+from __future__ import print_function
+
+import json
+
+from tabulate import tabulate
+
+from .schema import (mk_sample_event,
+                     mk_markdown_table,
+                     mk_redshift_table,
+                     mk_redshift_schema,
+                     mk_bigquery_table,
+                     mk_bigquery_schema)
+
+
+def jsonprint(obj):
+    print(json.dumps(obj, indent=4, sort_keys=True))
+
+
+def tableprint(table, headers):
+    print(tabulate(table, headers, tablefmt="pipe"))
+
+
+def br():
+    print()
+
+
+def main():
+    # TODO: CLI for creating various Markdown files
+    # which we can use for documentation in the repo,
+    # and we'll auto-generate them on release with GNU Make?
+    print("## Sample Event")
+    br()
+    print("```javascript")
+    jsonprint(mk_sample_event())
+    print("```")
+    br()
+    print("## Schema Overview")
+    br()
+    tableprint(*mk_markdown_table())
+    br()
+    print("## BigQuery Schema")
+    br()
+    tableprint(*mk_bigquery_table())
+    br()
+    print("## BigQuery DDL")
+    br()
+    print("```javascript")
+    jsonprint(mk_bigquery_schema())
+    print("```")
+    br()
+    print("## Redshift Schema")
+    br()
+    tableprint(*mk_redshift_table())
+    br()
+    print("## Redshift DDL")
+    br()
+    print("```sql")
+    print(mk_redshift_schema())
+    print("```")
+
+
+if __name__ == "__main__":
+    main()

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function
 
-from .schema import mk_redshift_table
+from .schema import mk_redshift_schema
 
 import psycopg2
 

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function
 
+from .schema import mk_redshift_table
+
 import psycopg2
 
 from . import utils
@@ -18,9 +20,17 @@ limitations under the License.
 """
 
 
-def create_table(host="", user="", password="", database="", port="5439"):
+def create_table(table_name="rawdata",
+                 host="",
+                 user="",
+                 password="",
+                 database="parsely",
+                 port="5439",
+                 debug=False):
     """Create a Redshift table using a schema compatible with Parse.ly events
 
+    :param table_name: The Redshift table name to use for creation
+    :type host: str
     :param host: The Redshift host on which to create the table
     :type host: str
     :param user: The Redshift user to use when creating the table
@@ -32,34 +42,11 @@ def create_table(host="", user="", password="", database="", port="5439"):
     :param port: The port on which to connect to Redshift
     :type port: str
     """
-    query = """
-CREATE TABLE events
-(
-    url                             VARCHAR(4096) NOT NULL,
-    apikey                          VARCHAR(256) NOT NULL,
-    action                          VARCHAR(256),
-    display_avail_height            INTEGER,
-    display_avail_width             INTEGER,
-    display_pixel_depth             INTEGER,
-    display_total_height            INTEGER,
-    display_total_width             INTEGER,
-    engaged_time_inc                INTEGER,
-    extra_data                      VARCHAR(4096),
-    referrer                        VARCHAR(1024),
-    session_id                      VARCHAR(256)
-    session_initial_referrer        VARCHAR(512),
-    session_initial_url             VARCHAR(512),
-    session_last_session_timestamp  TIMESTAMP,
-    session_timestamp               TIMESTAMP,
-    timestamp_info_nginx_ms         TIMESTAMP,
-    timestamp_info_override_ms      TIMESTAMP,
-    timestamp_info_pixel_ms         TIMESTAMP,
-    user_agent                      VARCHAR(512),
-    visitor_ip                      VARCHAR(128),
-    visitor_network_id              VARCHAR(128),
-    visitor_site_id                 VARCHAR(128)
-);
-"""
+    query = mk_redshift_schema()
+    query = query.replace("parsely.rawdata", table_name)
+    if debug:
+        print("Running the following Redshift CREATE TABLE command:")
+        print(query)
     connection = psycopg2.connect(host=host, port=port, user=user,
                                   password=password, database=database)
     connection.cursor().execute(query)
@@ -68,13 +55,15 @@ CREATE TABLE events
 
 def copy_from_s3(network,
                  s3_prefix,
+                 table_name="rawdata",
                  host="",
                  user="",
                  password="",
-                 database="",
+                 database="parsely",
                  port="5439",
                  access_key_id="",
-                 secret_access_key=""):
+                 secret_access_key="",
+                 debug=False):
     """Use the Redshift COPY command to copy event data from S3
 
     :param network: The Parse.ly network for which to copy data (eg
@@ -83,6 +72,8 @@ def copy_from_s3(network,
     :param s3_prefix: The S3 timestamp directory prefix from which to fetch data
         batches, formatted as YYYY/MM/DD
     :type s3_prefix: str
+    :param table_name: The Redshift table name to use for copying
+    :type host: str
     :param host: The Redshift host to which to write
     :type host: str
     :param user: The Redshift user to use when writing
@@ -98,17 +89,21 @@ def copy_from_s3(network,
     :param secret_access_key: The AWS secret key to use when copying
     :type secret_access_key: str
     """
-    connection = psycopg2.connect(host=host, port=port, user=user,
-                                  password=password, database=database)
-    query = "copy visits\n"
-    "from 's3://parsely-dw-{network}/{s3_prefix}'\n"
-    "credentials 'aws_access_key_id={aws_access_key_id};"
+    query = ""
+    "COPY {table_name}\n"
+    "FROM 's3://parsely-dw-{network}/{s3_prefix}'\n"
+    "CREDENTIALS 'aws_access_key_id={aws_access_key_id};"
     "aws_secret_access_key={aws_secret_access_key}'\n"
-    "json as 'auto' gzip;".format(
+    "JSON AS 'auto' GZIP;".format(
         network=utils.clean_network(network),
         s3_prefix=s3_prefix,
         aws_access_key_id=access_key_id,
         aws_secret_access_key=secret_access_key)
+    if debug:
+        print("Running the following Redshift COPY command:")
+        print(query)
+    connection = psycopg2.connect(host=host, port=port, user=user,
+                                  password=password, database=database)
     connection.cursor().execute(query)
     connection.commit()
 
@@ -117,6 +112,8 @@ def main():
     commands = ['copy_from_s3', 'create_table']
     parser = utils.get_default_parser("Amazon Redshift utilities for Parse.ly",
                                       commands=commands)
+    parser.add_argument("--table_name", type=str,
+                        help="The name of the Redshift table to create/copy")
     parser.add_argument('--redshift_host', type=str,
                         help='The host string of the Redshift instance to which to '
                              'connect, ending in "redshift.amazonaws.com"')
@@ -136,6 +133,7 @@ def main():
         copy_from_s3(
             args.network,
             args.s3_prefix,
+            table_name=args.table_name,
             host=args.redshift_host,
             user=args.redshift_user,
             password=args.redshift_password,
@@ -145,6 +143,7 @@ def main():
         )
     elif args.command == "create_table":
         create_table(
+            table_name=args.table_name,
             host=args.redshift_host,
             user=args.redshift_user,
             password=args.redshift_password,

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -43,7 +43,7 @@ def create_table(table_name="rawdata",
     :type port: str
     """
     query = mk_redshift_schema()
-    query = query.replace("parsely.rawdata", table_name)
+    query = query.replace(u"parsely.rawdata", table_name)
     if debug:
         print("Running the following Redshift CREATE TABLE command:")
         print(query)
@@ -112,7 +112,7 @@ def main():
     commands = ['copy_from_s3', 'create_table']
     parser = utils.get_default_parser("Amazon Redshift utilities for Parse.ly",
                                       commands=commands)
-    parser.add_argument("--table_name", type=str,
+    parser.add_argument("--table_name", type=str, default="rawdata",
                         help="The name of the Redshift table to create/copy")
     parser.add_argument('--redshift_host', type=str,
                         help='The host string of the Redshift instance to which to '
@@ -123,9 +123,9 @@ def main():
     parser.add_argument('--redshift_password', type=str,
                         help='The password to use when connecting to the Redshift'
                              ' instance')
-    parser.add_argument('--redshift_database', type=str,
+    parser.add_argument('--redshift_database', type=str, default="parsely",
                         help='The Redshift database to which to connect')
-    parser.add_argument('--redshift_port', type=str,
+    parser.add_argument('--redshift_port', type=str, default="5439",
                         help='The port on which to connect to Redshift')
     args = parser.parse_args()
 
@@ -139,7 +139,8 @@ def main():
             password=args.redshift_password,
             database=args.redshift_database,
             access_key_id=args.aws_access_key_id,
-            secret_access_key=args.aws_secret_access_key
+            secret_access_key=args.aws_secret_access_key,
+            debug=args.debug
         )
     elif args.command == "create_table":
         create_table(
@@ -148,7 +149,8 @@ def main():
             user=args.redshift_user,
             password=args.redshift_password,
             database=args.redshift_database,
-            port=args.redshift_port
+            port=args.redshift_port,
+            debug=args.debug
         )
 
 if __name__ == "__main__":

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -94,7 +94,8 @@ def copy_from_s3(network,
     "FROM 's3://parsely-dw-{network}/{s3_prefix}'\n"
     "CREDENTIALS 'aws_access_key_id={aws_access_key_id};"
     "aws_secret_access_key={aws_secret_access_key}'\n"
-    "JSON AS 'auto' GZIP;"
+    "JSON AS 'auto' GZIP\n"
+    "TRUNCATECOLUMNS;\n"
 	).format(
 	table_name=table_name,
         network=utils.clean_network(network),

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -89,12 +89,14 @@ def copy_from_s3(network,
     :param secret_access_key: The AWS secret key to use when copying
     :type secret_access_key: str
     """
-    query = ""
+    query = (
     "COPY {table_name}\n"
     "FROM 's3://parsely-dw-{network}/{s3_prefix}'\n"
     "CREDENTIALS 'aws_access_key_id={aws_access_key_id};"
     "aws_secret_access_key={aws_secret_access_key}'\n"
-    "JSON AS 'auto' GZIP;".format(
+    "JSON AS 'auto' GZIP;"
+	).format(
+	table_name=table_name,
         network=utils.clean_network(network),
         s3_prefix=s3_prefix,
         aws_access_key_id=access_key_id,

--- a/parsely_raw_data/s3.py
+++ b/parsely_raw_data/s3.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, print_function
 import gzip
 import json
 from collections import defaultdict
-from io import StringIO
+from io import BytesIO
 
 import boto3
 
@@ -56,7 +56,7 @@ def events_s3(network,
         res = client.list_objects(Bucket=bucket, Prefix=prefix)
         for item in res.get("Contents", []):
             obj = client.get_object(Bucket=bucket, Key=item.get("Key"))
-            with gzip.GzipFile(fileobj=StringIO(obj.get("Body").read()),
+            with gzip.GzipFile(fileobj=BytesIO(obj.get("Body").read()),
                                mode="rb") as f:
                 for part in [a for a in f.read().split('\n') if a]:
                     yield Event.from_dict(json.loads(part))

--- a/parsely_raw_data/s3.py
+++ b/parsely_raw_data/s3.py
@@ -59,7 +59,7 @@ def events_s3(network,
             with gzip.GzipFile(fileobj=BytesIO(obj.get("Body").read()),
                                mode="rb") as f:
                 for part in [a for a in f.read().split('\n') if a]:
-                    yield Event.from_dict(json.loads(part))
+                    yield json.loads(part)
 
 
 def main():

--- a/parsely_raw_data/samples.py
+++ b/parsely_raw_data/samples.py
@@ -1,0 +1,90 @@
+import json
+import os
+import tempfile
+
+import tablib
+import xlsxwriter
+
+from .schema import SCHEMA
+
+def gen_json2csv(jsonlines):
+    first_columns = ["action", "ts_action", "visitor_site_id", "url", "apikey"]
+    headers = [field["key"] for field in SCHEMA
+               if field["key"] not in first_columns]
+    headers = first_columns + headers
+    yield headers
+    for jsonline in jsonlines:
+        row = []
+        for field in headers:
+            cell = jsonline.get(field)
+            if cell is None:
+                cell = ""
+            if isinstance(cell, (dict, list)):
+                cell = json.dumps(cell)
+            row.append(cell)
+        yield row
+
+SAMPLE_SIZE_IN_ROWS = 50000
+
+def make_sample_dataset(jsonlines):
+    lines = []
+    # take first 50k jsonlines
+    for i, line in enumerate(jsonlines):
+        if i > SAMPLE_SIZE_IN_ROWS:
+            break
+        jsonline = json.loads(line)
+        lines.append(jsonline)
+    headers = None
+    body = []
+    for i, line in enumerate(gen_json2csv(lines)):
+        if i == 0:
+            headers = line
+            continue
+        else:
+            body.append(line)
+    data = tablib.Dataset(*body, headers=headers)
+    return data
+
+
+def make_xlsx(rows):
+    tmp_path = tempfile.mktemp()
+    workbook = xlsxwriter.Workbook(tmp_path, {'strings_to_numbers': False,
+                                              'strings_to_formulas': False,
+                                              'strings_to_urls': False})
+    worksheet = workbook.add_worksheet()
+    worksheet.write_row(0, 0, rows.headers)
+    for i, row in enumerate(rows):
+        worksheet.write_row(i + 1, 0, row)
+    workbook.close()
+    contents = open(tmp_path, "rb").read()
+    os.remove(tmp_path)
+    return contents
+
+
+if __name__ == "__main__":
+    import csv
+    print("CSV file self-test...")
+    tmp_path = tempfile.mktemp()
+    with open(tmp_path, "w") as csv_file:
+        csv_writer = csv.writer(csv_file)
+        for line in gen_json2csv([{"visitor_site_id": "1",
+                                   "apikey": "qz.com",
+                                   "ts_action": "2016-11-26 08:30:57",
+                                   "action": "pageview",
+                                   "extra_data": {"present": True},
+                                   "url": "http://qz.com/1234"}]):
+            csv_writer.writerow(line)
+    for i, line in enumerate(open(tmp_path).readlines()):
+        print(line[:80])
+    os.remove(tmp_path)
+    print("Done.")
+
+    print("Generating CSV and XLSX sample from sample.json.gz...")
+    import gzip
+    with open("sample.csv", "w") as csv_file, \
+         open("sample.xlsx", "wb") as xlsx_file:
+        jsonlines = gzip.GzipFile("sample.json.gz")
+        data = make_sample_dataset(jsonlines)
+        csv_file.write(data.csv)
+        xlsx_file.write(make_xlsx(data))
+    print("Done.")

--- a/parsely_raw_data/samples.py
+++ b/parsely_raw_data/samples.py
@@ -81,7 +81,6 @@ def main():
     json_input = args.json_input
     output = args.output
     row_limit = args.row_limit
-    print(row_limit)
     if output.endswith(".csv"):
         open_spec = (output, "w")
         converter = make_csv

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -143,6 +143,10 @@ def mk_bigquery_schema():
     jsonlines = []
     for row in table:
         key, _, type_ = row
+        if type_ == "RECORD":
+            # skip record types since it requires additional
+            # modelling from the user
+            continue
         if "REPEATED" in type_:
             type_ = type_.split(" ")[0]
             mode = "REPEATED"

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -160,9 +160,9 @@ def mk_bigquery_schema():
     return jsonlines
 
 
-def mk_spark_sql_schema():
+def mk_spark_sql_schema(with_visitor_partition=False):
     from pyspark.sql.types import (
-        ArrayType, BooleanType, DoubleType,
+        ArrayType, BooleanType, DoubleType, IntegerType,
         LongType, StringType, StructType)
 
     schema = StructType()
@@ -183,6 +183,8 @@ def mk_spark_sql_schema():
             schema.add(k, ArrayType(StringType()))
         else:
             raise TypeError, "Don't know how to parse field %s of type %s" % (k, typ)
+    if with_visitor_partition:
+        schema.add("visitor_partition", IntegerType())
     return schema
 
 

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -170,8 +170,8 @@ def mk_spark_sql_schema(with_visitor_partition=False):
         k = field['key']
         typ = field['type']
         if k == "metadata_share_urls":
-            schema.add(l, StringType())
-        if typ is str:
+            schema.add(k, StringType())
+        elif typ is str:
             schema.add(k, StringType())
         elif typ is int:
             schema.add(k, LongType())

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -1,0 +1,215 @@
+from __future__ import print_function
+
+SCHEMA = [
+    {"key": "action", "ex": "pageview", "type": str, "size": 256},
+    {"key": "apikey", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "display", "ex": True, "type": bool},
+    {"key": "display_avail_height", "ex": 735, "type": int},
+    {"key": "display_avail_width", "ex": 1280, "type": int},
+    {"key": "display_pixel_depth", "ex": 24, "type": int},
+    {"key": "display_total_height", "ex": 800, "type": int},
+    {"key": "display_total_width", "ex": 1280, "type": int},
+    {"key": "engaged_time_inc", "ex": None, "type": int},
+    {"key": "extra_data", "ex": None, "type": object},
+    {"key": "ip_city", "ex": "Newark", "type": str},
+    {"key": "ip_continent", "ex": "NA", "type": str, "size": 2},
+    {"key": "ip_country", "ex": "US", "type": str, "size": 2},
+    {"key": "ip_lat", "ex": 37.5147, "type": float},
+    {"key": "ip_lon", "ex": -122.0423, "type": float},
+    {"key": "ip_postal", "ex": "94560", "type": str, "size": 64},
+    {"key": "ip_subdivision", "ex": "CA", "type": str, "size": 2},
+    {"key": "ip_timezone", "ex": "America/Los_Angeles", "type": str, "size": 256},
+    {"key": "metadata", "ex": True, "type": bool},
+    {"key": "metadata_authors", "ex": ["Laura Vitto"], "type": list},
+    {"key": "metadata_canonical_url", "ex": "http://mashable.com/2016/09/07/airpods-jokes/", "type": str},
+    {"key": "metadata_custom_metadata", "ex": "{\"site\":\"Mashable\"}", "type": str},
+    {"key": "metadata_duration", "ex": None, "type": int},
+    {"key": "metadata_full_content_word_count", "ex": 174, "type": int},
+    {"key": "metadata_image_url", "ex": "http://a.amz.mshcdn.com/media/ZgkyMDE2LzA5LzA3LzU2L0NyeFhpNjNYRUFBSnZwRS5lNDAyMy5qcGcKcAl0aHVtYgkxMjAweDYzMAplCWpwZw/156d0173/3ae/CrxXi63XEAAJvpE.jpg", "type": str},
+    {"key": "metadata_page_type", "ex": "post", "type": str, "size": 256},
+    {"key": "metadata_post_id", "ex": "http://mashable.com/2016/09/07/airpods-jokes/", "type": str},
+    {"key": "metadata_pub_date_tmsp", "ex": 1473275118000, "type": int, "date": True},
+    {"key": "metadata_save_date_tmsp", "ex": 1473275204000, "type": int, "date": True},
+    {"key": "metadata_section", "ex": "watercooler", "type": str, "size": 256},
+    {"key": "metadata_share_urls", "ex": None, "type": list},
+    {"key": "metadata_tags", "ex": ["gadgets", "iphone-7"], "type": list},
+    {"key": "metadata_thumb_url", "ex": "https://images.parsely.com/xY9xNBMulGDKRMzfKaUQzs7A9PA=/160x160/smart/http%3A//a.amz.mshcdn.com/media/ZgkyMDE2LzA5LzA3LzU2L0NyeFhpNjNYRUFBSnZwRS5lNDAyMy5qcGcKcAl0aHVtYgkxMjAweDYzMAplCWpwZw/156d0173/3ae/CrxXi63XEAAJvpE.jpg", "type": str},
+    {"key": "metadata_title", "ex": "Everyone has the same fear about Apple's new earbuds", "type": str},
+    {"key": "metadata_urls", "ex": ["http://mashable.com/2016/09/07/airpods-jokes/"], "type": str},
+    {"key": "ref_category", "ex": "internal", "type": str, "size": 64},
+    {"key": "ref_clean", "ex": "http://mashable.com/", "type": str},
+    {"key": "ref_domain", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "ref_fragment", "ex": "", "type": str},
+    {"key": "ref_netloc", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "ref_params", "ex": "", "type": str},
+    {"key": "ref_path", "ex": "/", "type": str},
+    {"key": "ref_query", "ex": "", "type": str},
+    {"key": "ref_scheme", "ex": "http", "type": str, "size": 64},
+    {"key": "referrer", "ex": "http://mashable.com/", "type": str},
+    {"key": "session", "ex": True, "type": bool},
+    {"key": "session_id", "ex": 6, "type": int},
+    {"key": "session_initial_referrer", "ex": "http://mashable.com/", "type": str},
+    {"key": "session_initial_url", "ex": "http://mashable.com/", "type": str},
+    {"key": "session_last_session_timestamp", "ex": 1473271351611, "type": int, "date": True},
+    {"key": "session_timestamp", "ex": 1473277747806, "type": int, "date": True},
+    {"key": "slot", "ex": False, "type": bool},
+    {"key": "sref_category", "ex": "internal", "type": str, "size": 64},
+    {"key": "sref_clean", "ex": "http://mashable.com/", "type": str},
+    {"key": "sref_domain", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "sref_fragment", "ex": "", "type": str},
+    {"key": "sref_netloc", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "sref_params", "ex": "", "type": str},
+    {"key": "sref_path", "ex": "/", "type": str},
+    {"key": "sref_query", "ex": "", "type": str},
+    {"key": "sref_scheme", "ex": "http", "type": str, "size": 64},
+    {"key": "surl_clean", "ex": "http://mashable.com/", "type": str},
+    {"key": "surl_domain", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "surl_fragment", "ex": "", "type": str},
+    {"key": "surl_netloc", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "surl_params", "ex": "", "type": str},
+    {"key": "surl_path", "ex": "/", "type": str},
+    {"key": "surl_query", "ex": "", "type": str},
+    {"key": "surl_scheme", "ex": "http", "type": str, "size": 64},
+    {"key": "timestamp_info", "ex": True, "type": bool},
+    {"key": "timestamp_info_nginx_ms", "ex": 1473277850000, "type": int, "date": True},
+    {"key": "timestamp_info_override_ms", "ex": None, "type": int, "date": True},
+    {"key": "timestamp_info_pixel_ms", "ex": 1473277850017, "type": int, "date": True},
+    {"key": "ts_action", "ex": "2016-09-07 19:50:50", "type": str, "date": True},
+    {"key": "ts_session_current", "ex": "2016-09-07 19:49:07", "type": str, "date": True},
+    {"key": "ts_session_last", "ex": "2016-09-07 18:02:31", "type": str, "date": True},
+    {"key": "ua_browser", "ex": "Safari", "type": str},
+    {"key": "ua_browserversion", "ex": "9.1.2", "type": str},
+    {"key": "ua_device", "ex": "Other", "type": str},
+    {"key": "ua_devicebrand", "ex": None, "type": str},
+    {"key": "ua_devicemodel", "ex": None, "type": str},
+    {"key": "ua_devicetouchcapable", "ex": True, "type": bool},
+    {"key": "ua_devicetype", "ex": "desktop", "type": str},
+    {"key": "ua_os", "ex": "Mac OS X", "type": str},
+    {"key": "ua_osversion", "ex": "10.10.5", "type": str},
+    {"key": "url", "ex": "http://mashable.com/2016/09/07/airpods-jokes/#L.eZPflSGqq5", "type": str},
+    {"key": "url_clean", "ex": "http://mashable.com/2016/09/07/airpods-jokes/", "type": str},
+    {"key": "url_domain", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "url_fragment", "ex": "L.eZPflSGqq5", "type": str},
+    {"key": "url_netloc", "ex": "mashable.com", "type": str, "size": 256},
+    {"key": "url_params", "ex": "", "type": str},
+    {"key": "url_path", "ex": "/2016/09/07/airpods-jokes/", "type": str},
+    {"key": "url_query", "ex": "", "type": str},
+    {"key": "url_scheme", "ex": "http", "type": str, "size": 64},
+    {"key": "user_agent", "ex": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/601.7.7 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.7", "type": str},
+    {"key": "version", "ex": 1, "type": int},
+    {"key": "visitor", "ex": True, "type": bool},
+    {"key": "visitor_ip", "ex": "108.225.131.20", "type": str, "size": 256},
+    {"key": "visitor_network_id", "ex": "ac94fe31-a307-4020-9a23-fa4798217b02", "type": str, "size": 128},
+    {"key": "visitor_site_id", "ex": "ab94fd31-a207-4010-8a25-fb4788207b82", "type": str, "size": 128}
+]
+
+
+import json
+from tabulate import tabulate
+
+
+def mk_sample_json():
+    sample = {}
+    for record in SCHEMA:
+        sample[record["key"]] = record["ex"]
+    return sample
+
+
+def mk_bigquery_schema():
+    table = []
+    headers = ["Column", "Example", "Type"]
+    for record in SCHEMA:
+        key = record["key"]
+        example = record["ex"]
+        types2str = {
+            str: "STRING",
+            int: "INTEGER",
+            float: "FLOAT",
+            bool: "BOOLEAN",
+            object: "RECORD",
+            list: "STRING (REPEATED)"
+        }
+        type_ = types2str[record["type"]]
+        if type_ == "STRING":
+            if example and len(example) > 25:
+                example = example[0:23] + "..."
+        table.append([key, example, type_])
+    return tabulate(table, headers, tablefmt="pipe")
+
+
+def mk_redshift_schema():
+    table = []
+    headers = ["Column", "Example", "Type"]
+    for record in SCHEMA:
+        key = record["key"]
+        example = record["ex"]
+        types2str = {
+            str: "VARCHAR(4096)",
+            int: "INTEGER",
+            float: "FLOAT",
+            bool: "BOOLEAN",
+            object: "VARCHAR(MAX)",
+            list: "VARCHAR(MAX)"
+        }
+        type_ = types2str[record["type"]]
+        if type_ == "VARCHAR(4096)":
+            if record.get("size", False):
+                type_ = "VARCHAR(%s)" % record["size"]
+            if example and len(example) > 25:
+                example = example[0:23] + "..."
+        if record.get("date", False) and key.startswith("ts_"):
+            type_ = "TIMESTAMP"
+        table.append([key, example, type_])
+    return tabulate(table, headers, tablefmt="pipe")
+
+
+def mk_markdown_table(prefix=None):
+    table = []
+    headers = ["Key", "Example", "Type"]
+    for record in SCHEMA:
+        key = record["key"]
+        if prefix is not None:
+            if not key.startswith(prefix):
+                continue
+        example = record["ex"]
+        types2str = {
+            str: "STRING",
+            int: "INTEGER",
+            float: "FLOAT",
+            bool: "BOOLEAN",
+            object: "JSON",
+            list: "LIST"
+        }
+        type_ = types2str[record["type"]]
+        if type_ == "STRING":
+            if example and len(example) > 25:
+                example = example[0:23] + "..."
+        if record.get("date", False):
+            type_ = "DATE (%s)" % type_
+        table.append([key, example, type_])
+    return tabulate(table, headers, tablefmt="pipe")
+
+
+def jsonprint(obj):
+    print(json.dumps(obj, indent=4, sort_keys=True))
+
+
+if __name__ == "__main__":
+    print("## Sample JSON event:")
+    print()
+    print("```javascript")
+    jsonprint(mk_sample_json())
+    print("```")
+    print()
+    print("## Schema Overview")
+    print()
+    print(mk_markdown_table())
+    print()
+    print("## BigQuery Schema")
+    print()
+    print(mk_bigquery_schema())
+    print()
+    print("## Redshift Schema")
+    print()
+    print(mk_redshift_schema())
+    print()

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -108,7 +108,7 @@ import json
 from tabulate import tabulate
 
 
-def mk_sample_json():
+def mk_sample_event():
     sample = {}
     for record in SCHEMA:
         sample[record["key"]] = record["ex"]
@@ -133,6 +133,7 @@ def mk_bigquery_schema():
         if type_ == "STRING":
             if example and len(example) > 25:
                 example = example[0:23] + "..."
+            example = repr(example)
         table.append([key, example, type_])
     return tabulate(table, headers, tablefmt="pipe")
 
@@ -157,6 +158,7 @@ def mk_redshift_schema():
                 type_ = "VARCHAR(%s)" % record["size"]
             if example and len(example) > 25:
                 example = example[0:23] + "..."
+            example = repr(example)
         if record.get("date", False) and key.startswith("ts_"):
             type_ = "TIMESTAMP"
         table.append([key, example, type_])
@@ -184,6 +186,7 @@ def mk_markdown_table(prefix=None):
         if type_ == "STRING":
             if example and len(example) > 25:
                 example = example[0:23] + "..."
+            example = repr(example)
         if record.get("date", False):
             type_ = "DATE (%s)" % type_
         table.append([key, example, type_])
@@ -195,10 +198,10 @@ def jsonprint(obj):
 
 
 if __name__ == "__main__":
-    print("## Sample JSON event:")
+    print("## Sample Event")
     print()
     print("```javascript")
-    jsonprint(mk_sample_json())
+    jsonprint(mk_sample_event())
     print("```")
     print()
     print("## Schema Overview")

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -160,6 +160,32 @@ def mk_bigquery_schema():
     return jsonlines
 
 
+def mk_spark_sql_schema():
+    from pyspark.sql.types import (
+        ArrayType, BooleanType, DoubleType,
+        LongType, StringType, StructType)
+
+    schema = StructType()
+    for field in SCHEMA:
+        k = field['key']
+        typ = field['type']
+        if typ is str:
+            schema.add(k, StringType())
+        elif typ is int:
+            schema.add(k, LongType())
+        elif typ is float:
+            schema.add(k, DoubleType())
+        elif typ is bool:
+            schema.add(k, BooleanType())
+        elif typ is object:
+            schema.add(k, StringType())
+        elif typ is list:
+            schema.add(k, ArrayType(StringType()))
+        else:
+            raise TypeError, "Don't know how to parse field %s of type %s" % (k, typ)
+    return schema
+
+
 def mk_redshift_table():
     table = []
     headers = ["Column", "Example", "Type"]

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -169,6 +169,8 @@ def mk_spark_sql_schema(with_visitor_partition=False):
     for field in SCHEMA:
         k = field['key']
         typ = field['type']
+        if k == "metadata_share_urls":
+            schema.add(l, StringType())
         if typ is str:
             schema.add(k, StringType())
         elif typ is int:

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -280,44 +280,7 @@ def mk_markdown_table(prefix=None):
     return table, headers
 
 
-def jsonprint(obj):
-    print(json.dumps(obj, indent=4, sort_keys=True))
-
-
-def tableprint(table, headers):
-    print(tabulate(table, headers, tablefmt="pipe"))
-
-def br():
-    print()
-
-
 if __name__ == "__main__":
-    print("## Sample Event")
-    br()
-    print("```javascript")
-    jsonprint(mk_sample_event())
-    print("```")
-    br()
-    print("## Schema Overview")
-    br()
-    tableprint(*mk_markdown_table())
-    br()
-    print("## BigQuery Schema")
-    br()
-    tableprint(*mk_bigquery_table())
-    br()
-    print("## BigQuery DDL")
-    br()
-    print("```javascript")
-    jsonprint(mk_bigquery_schema())
-    print("```")
-    br()
-    print("## Redshift Schema")
-    br()
-    tableprint(*mk_redshift_table())
-    br()
-    print("## Redshift DDL")
-    br()
-    print("```sql")
-    print(mk_redshift_schema())
-    print("```")
+    # TODO: CLI for just showing the various DDLs
+    from .docgen import main
+    main()

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -226,6 +226,8 @@ def mk_redshift_table():
             example = repr(example)
         if record.get("date", False) and key.startswith("ts_"):
             type_ = "TIMESTAMP"
+	elif record.get("date", False):
+	    type_ = "BIGINT"
         if record.get("req", False):
             type_ = type_ + " NOT NULL"
         table.append([key, example, type_])

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -34,7 +34,7 @@ SCHEMA = [
     {"key": "ip_lat", "ex": 37.5147, "type": float},
     {"key": "ip_lon", "ex": -122.0423, "type": float},
     {"key": "ip_postal", "ex": "94560", "type": str, "size": 64},
-    {"key": "ip_subdivision", "ex": "CA", "type": str, "size": 2},
+    {"key": "ip_subdivision", "ex": "CA", "type": str, "size": 3},
     {"key": "ip_timezone", "ex": "America/Los_Angeles", "type": str, "size": 256},
     {"key": "metadata", "ex": True, "type": bool},
     {"key": "metadata_authors", "ex": ["Laura Vitto"], "type": list},

--- a/parsely_raw_data/stream.py
+++ b/parsely_raw_data/stream.py
@@ -69,7 +69,7 @@ def events_kinesis(network, access_key_id="", secret_access_key=""):
                         event_data = json.loads(event_data)
                     except ValueError:
                         continue
-                    event_queue.put(Event.from_dict(event_data['payload']))
+                    event_queue.put(Event.from_dict(event_data))
 
     workers = []
     description = {"HasMoreShards": True}

--- a/parsely_raw_data/utils.py
+++ b/parsely_raw_data/utils.py
@@ -36,6 +36,8 @@ def get_default_parser(description, commands=None):
     parser.add_argument('--s3_prefix', type=str,
                         help='The date prefix to use when copying from S3, formatted as '
                              'YYYY/MM/DD')
+    parser.add_argument('--debug', action='store_true',
+                        help='Turn on debug mode to log output and commands')
     if commands is not None:
         parser.add_argument('command', type=str,
                             help='The operation to perform',

--- a/parsely_raw_data/utils.py
+++ b/parsely_raw_data/utils.py
@@ -34,10 +34,10 @@ def get_default_parser(description, commands=None):
     parser.add_argument('--aws_region_name', type=str,
                         help='The AWS region to which to connect')
     parser.add_argument('--s3_prefix', type=str,
-                        help='The date prefix to use when copying from S3, formatted as'
+                        help='The date prefix to use when copying from S3, formatted as '
                              'YYYY/MM/DD')
     if commands is not None:
-        parser.add_argument('--command', type=str,
+        parser.add_argument('command', type=str,
                             help='The operation to perform',
                             choices=commands)
     return parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ boto3==1.2.3
 google-api-python-client
 psycopg2
 six
-thriftpy
+tablib
+xlsxwriter

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ def get_version():
 
 install_requires = [
     'six',
-    'thriftpy'
 ]
 
 lint_requires = [


### PR DESCRIPTION
Rough idea here:
- took [our example DPL record format in JSON here](http://www.parsely.com/help/rawdata/schema/#example-json-page-view-record)
- applied some vim macro magic to transform it into the `SCHEMA` Python dict in this module, which describes: a `key`; an `ex` (example) value; a `type`, and optionally a `size` or indicator whether it's a `date` field
- this little DDL describes our schema in such a way that I can automatically generate three outputs: (1) a Markdown table usable in our technical docs (using `tabulate` and its handy `pipe` format); (2) an actual BigQuery schema and associated Markdown table describing the schema; and (3) an actual Redshift schema and associated Markdown table describing the schema.

I'll then refactor the `redshift` and `bigquery` modules to source the schema from this module, rather than having hard-coded variants of their own. You can see an example of [what this module currently generates here](https://gist.github.com/amontalenti/e342315f5d6eecf8e3796c7cacc7e886).
