### PR TITLE
Allow publishers to load JSON formatted fields (extra_data) into Redshift as a VARCHAR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,14 +45,16 @@ them yourselves using your own Python scripts.
 Module and CLI Guide
 ~~~~~~~~~~~~~~~~~~~~
 
-If you have the project installed in a virtualenv, you can use the following console scripts:
+If you have the project installed with `pip`, you can use the following console scripts anywhere:
 
 * ``parsely_redshift`` = ``parsely_raw_data.redshift``
 * ``parsely_bigquery`` = ``parsely_raw_data.bigquery``
 * ``parsely_s3`` = ``parsely_raw_data.s3``
 * ``parsely_stream`` = ``parsely_raw_data.stream``
 
-Alternately, you can run each module like this:
+Alternately, you can clone the repo, and run each module from within the repo directory, like this:
+
+``cd <path_to_parsely_raw_data_repo_directory>``
 
 * ``python -m parsely_raw_data.samples``: Generate data samples in CSV and XLSX format
 * ``python -m parsely_raw_data.s3``: Fetch archived event data from Parse.ly S3 Bucket

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,15 @@ them yourselves using your own Python scripts.
 Module and CLI Guide
 ~~~~~~~~~~~~~~~~~~~~
 
+If you have the project installed in a virtualenv, you can use the following console scripts:
+
+* ``parsely_redshift`` = ``parsely_raw_data.redshift``
+* ``parsely_bigquery`` = ``parsely_raw_data.bigquery``
+* ``parsely_s3`` = ``parsely_raw_data.s3``
+* ``parsely_stream`` = ``parsely_raw_data.stream``
+
+Alternately, you can run each module like this:
+
 * ``python -m parsely_raw_data.samples``: Generate data samples in CSV and XLSX format
 * ``python -m parsely_raw_data.s3``: Fetch archived event data from Parse.ly S3 Bucket
 * ``python -m parsely_raw_data.stream``: Consume a Parse.ly Kinesis Stream of real-time event data

--- a/docs/redshift.rst
+++ b/docs/redshift.rst
@@ -1,0 +1,26 @@
+Redshift
+==========
+
+Loading data from s3 into Redshift can be accomplished in two steps:
+
+1) Create a Redshift table using `python -m parsely_raw_data.redshift create_table <args>`
+
+2) Copy data from your Parse.ly S3 bucket using `python -m parsely_raw_data.redshift copy_from_s3 <args>`
+
+optional: Inspect database errors with `python -m parsely_raw_data.redshift inspect_errors`
+
+
+
+JSON extra_data and Redshift
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`extra_data`, where we store any customer-originated fields sent on a pixel, is a 
+JSON field. Redshift does not have a native JSON data type. Instead, you have the 
+option to ignore JSON fields, or load them as a JSON-formatted VARCHAR string.
+
+Use the `keep_extra_data` option when creating your Redshift table:
+
+`python -m parsely_raw_data.redshift create_table --keep_extra_data <redshift args>`
+
+You can query JSON string-formatted fields in Redshift using their JSON-parsing functions.
+

--- a/docs/redshift.rst
+++ b/docs/redshift.rst
@@ -3,24 +3,27 @@ Redshift
 
 Loading data from s3 into Redshift can be accomplished in two steps:
 
-1) Create a Redshift table using `python -m parsely_raw_data.redshift create_table <args>`
+1) Create a Redshift table using ``python -m parsely_raw_data.redshift create_table <args>``
 
-2) Copy data from your Parse.ly S3 bucket using `python -m parsely_raw_data.redshift copy_from_s3 <args>`
+2) Copy data from your Parse.ly S3 bucket using ``python -m parsely_raw_data.redshift copy_from_s3 <args>``
 
-optional: Inspect database errors with `python -m parsely_raw_data.redshift inspect_errors`
+optional: Inspect database errors with ``python -m parsely_raw_data.redshift inspect_errors``
 
 
 
 JSON extra_data and Redshift
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`extra_data`, where we store any customer-originated fields sent on a pixel, is a 
+``extra_data``, where we store any customer-originated fields sent on a pixel, is a 
 JSON field. Redshift does not have a native JSON data type. Instead, you have the 
 option to ignore JSON fields, or load them as a JSON-formatted VARCHAR string.
 
-Use the `keep_extra_data` option when creating your Redshift table:
+Use the ``keep_extra_data`` option when creating your Redshift table if you want
+to create a VARCHAR column to store `extra_data` as a JSON string:
 
-`python -m parsely_raw_data.redshift create_table --keep_extra_data <redshift args>`
+``python -m parsely_raw_data.redshift create_table --keep_extra_data <redshift args>``
 
-You can query JSON string-formatted fields in Redshift using their JSON-parsing functions.
+You can query JSON string-formatted fields in Redshift using their JSON-parsing functions, e.g.:
+
+``psql>>> select json_extract_path_text(extra_data, 'subscriberType') from <tablename> where extra_data IS NOT null;``
 

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -155,7 +155,7 @@ def main():
                         help='The Redshift database to which to connect')
     parser.add_argument('--redshift_port', type=str, default="5439",
                         help='The port on which to connect to Redshift')
-    parser.add_argument('--keep-extra-data', dest="keep_extra_data", default=False, action="store_true",
+    parser.add_argument('--keep-extra-data', action="store_true",
                         help='Optional: create a VARCHAR column for extra_data, which'
                              ' will be saved as a JSON-formatted string.')
     args = parser.parse_args()

--- a/parsely_raw_data/redshift.py
+++ b/parsely_raw_data/redshift.py
@@ -21,6 +21,7 @@ limitations under the License.
 
 
 def create_table(table_name="rawdata",
+                 keep_extra_data=False,
                  host="",
                  user="",
                  password="",
@@ -42,7 +43,7 @@ def create_table(table_name="rawdata",
     :param port: The port on which to connect to Redshift
     :type port: str
     """
-    query = mk_redshift_schema()
+    query = mk_redshift_schema(keep_extra_data=keep_extra_data)
     query = query.replace(u"parsely.rawdata", table_name)
     if debug:
         print("Running the following Redshift CREATE TABLE command:")
@@ -154,6 +155,9 @@ def main():
                         help='The Redshift database to which to connect')
     parser.add_argument('--redshift_port', type=str, default="5439",
                         help='The port on which to connect to Redshift')
+    parser.add_argument('--keep-extra-data', dest="keep_extra_data", default=False, action="store_true",
+                        help='Optional: create a VARCHAR column for extra_data, which'
+                             ' will be saved as a JSON-formatted string.')
     args = parser.parse_args()
 
     if args.command == "copy_from_s3":
@@ -172,6 +176,7 @@ def main():
     elif args.command == "create_table":
         create_table(
             table_name=args.table_name,
+            keep_extra_data=args.keep_extra_data,
             host=args.redshift_host,
             user=args.redshift_user,
             password=args.redshift_password,

--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -246,7 +246,7 @@ def mk_redshift_table():
     return table, headers
 
 
-def mk_redshift_schema():
+def mk_redshift_schema(keep_extra_data=False):
     table, headers = mk_redshift_table()
     ddl = []
     # open
@@ -254,9 +254,13 @@ def mk_redshift_schema():
     for row in table:
         key, _, type_ = row
         if type_ == "JSON":
-            # skip JSON type since we can't do anything with it
-            # without additional ETL steps
-            continue
+            # skip JSON type, unless we want to explicitly
+            # store JSON data as a VARCHAR
+            if keep_extra_data:
+                # convert to VARCHAR
+                type_ = "VARCHAR(4096)"
+            else:
+                continue
         # each line of DDL with key/type
         ddl.append("{:8}{:35} {:25}".format(" ", key, type_ + ","))
     # strip trailing comma


### PR DESCRIPTION
As @rachelannelise pointed out [here](https://github.com/Parsely/web/issues/6861), `extra_data` is currently ignored for Redshift loads from S3.

For publishers that do want this data, they can query it as JSON-formatted VARCHAR, so we can give them an option to do so by passing a `--keep-extra-data` option when creating the table.

This should be backwards compatible, so minor version change.

Also added:
 - some docs for `redshift.py` explaining the option
 - updates to docs to point out console scripts options