### PR TITLE
make action field nullable

### DIFF
--- a/parsely_raw_data/schema.py
+++ b/parsely_raw_data/schema.py
@@ -18,7 +18,7 @@ export these to example record formats, BigQuery/Redshift DDLs,
 and documentation in Markdown format.
 """
 SCHEMA = [
-    {"key": "action", "ex": "pageview", "type": str, "size": 256, "req": True},
+    {"key": "action", "ex": "pageview", "type": str, "size": 256},
     {"key": "apikey", "ex": "mashable.com", "type": str, "size": 256, "req": True},
     {"key": "campaign_id", "ex": "facebook_campaign", "type": str, "size": 256},
     {"key": "display", "ex": True, "type": bool},


### PR DESCRIPTION
#What it says. Allows customers to make DPL events that have no action attached to them, when an action is perhaps not appropriate or is undesired.

This *should* only affect creation of new tables for Redshift; our BQ table creation function makes all types that aren't `REPEATED` nullable by default, `mk_spark_sql_schema` doesn't specify.